### PR TITLE
Correctly handle blocking function. Store channels in JSON - Remove dailychannels.txt. ReadMe update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-# LeetCode Bot
+# LeetCode-Bot
 
-LeetCode Bot is a Discord bot designed to enhance your LeetCode experience. It provides various features such as sending questions, keeping track of a leaderboard, and more.
+Get ready for an epic coding showdown with the LeetCode Bot! Compare daily, weekly and all-time stats and conquer LeetCode together in the ultimate quest for coding glory.
 
-## Current Features
+[⚔️ Invite me to your server!](https://discord.com/api/oauth2/authorize?client_id=1059122559066570885&permissions=397284604928&scope=bot%20applications.commands)
 
-- `/help` - List of available commands.
-- `/question` - Receive a random LeetCode question.
-- `/add` - Add your account to the leaderboard.
-- `/stats` - Retrieve statistics of a user's LeetCode account.
-- `/remove` - Remove your account from the leaderboard.
-- `/daily` - Retrieve the daily LeetCode problem.
+## Commands
 
-## Administrators
+[Full list of commands here](https://github.com/Kevin-Roman/LeetCode-Discord-Bot/wiki/Commands)
 
-The following commands are exclusively available for administrators:
 
-- `/setdailychannel` - Set the channel where daily problems will be sent.
-- `/removedailychannel` - Remove a channel that receives daily problems.
+## Tools
 
-## Invite Link
-https://discord.com/api/oauth2/authorize?client_id=1059122559066570885&permissions=397284604928&scope=bot%20applications.commands
+- discord.py
+- [LeetCode API](https://leetcode.com/graphql)
+
+\*_Not affiliated with LeetCode. LeetCode API is only used as a tool for this bot._
+
+## Contributions
+
+Contributions are welcomed and encouraged!

--- a/bot_globals.py
+++ b/bot_globals.py
@@ -29,4 +29,4 @@ DIFFICULTY_SCORE = {"easy": 1, "medium": 3, "hard": 7}
 RANK_EMOJI = {1: "🥇", 2: "🥈", 3: "🥉"}
 
 TIMEFRAME_TITLE = {"alltime": {"field": "total_score",
-                               "title": "All-Time"}, "weekly": {"field": "week_score", "title": "Weekly", "win_title": "weeks won"}, "daily": {"field": "today_score", "title": "Daily", "win_title": "days won"}}
+                               "title": "All-Time"}, "weekly": {"field": "week_score", "title": "Weekly"}, "daily": {"field": "today_score", "title": "Daily"}}

--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -60,24 +60,25 @@ class Channels(commands.Cog):
                 channels = file.readlines()
                 logger.info(
                     "file: cogs/channels.py ~ removedailychannel ~ channel id: %s", channel.id)
-                if str(channel.id) + "\n" in channels or channel.id in channels:
-                    with open("dailychannels.txt", "w", encoding="UTF-8") as file:
-                        for line in channels:
-                            if line.strip("\n") != str(channel.id):
-                                file.write(line)
-                    embed = discord.Embed(
-                        title="Success!",
-                        description="This channel has been removed as the daily channel!",
-                        color=discord.Color.green())
-                    await interaction.response.send_message(embed=embed, ephemeral=True)
-                    return
-                else:
-                    embed = discord.Embed(
-                        title="Error!",
-                        description="This channel is not set as the daily channel!",
-                        color=discord.Color.red())
-                    await interaction.response.send_message(embed=embed, ephemeral=True)
-                    return
+
+            if str(channel.id) + "\n" in channels or channel.id in channels:
+                with open("dailychannels.txt", "w", encoding="UTF-8") as file:
+                    for line in channels:
+                        if line.strip("\n") != str(channel.id):
+                            file.write(line)
+                embed = discord.Embed(
+                    title="Success!",
+                    description="This channel has been removed as the daily channel!",
+                    color=discord.Color.green())
+                await interaction.response.send_message(embed=embed, ephemeral=True)
+                return
+            else:
+                embed = discord.Embed(
+                    title="Error!",
+                    description="This channel is not set as the daily channel!",
+                    color=discord.Color.red())
+                await interaction.response.send_message(embed=embed, ephemeral=True)
+                return
         else:
             embed = discord.Embed(
                 title="Error!",

--- a/cogs/leaderboards.py
+++ b/cogs/leaderboards.py
@@ -78,10 +78,10 @@ class Pagination(discord.ui.View):
         await interaction.message.delete()
 
 
-async def create_leaderboard(send_message, guild_id, user_id = None, timeframe: str = "alltime", page: int = 1, winners_only: bool = False, users_per_page: int = 10):
-    logger.info("file: cogs/leaderboards.py ~ create_leaderboard ~ run ~ guild id: %s", guild_id)
+async def display_leaderboard(send_message, server_id, user_id = None, timeframe: str = "alltime", page: int = 1, winners_only: bool = False, users_per_page: int = 10):
+    logger.info("file: cogs/leaderboards.py ~ display_leaderboard ~ run ~ guild id: %s", server_id)
 
-    if not os.path.exists(f"data/{guild_id}_leetcode_stats.json"):
+    if not os.path.exists(f"data/{server_id}_leetcode_stats.json"):
         embed = discord.Embed(
             title=f"{TIMEFRAME_TITLE[timeframe]['title']} Leaderboard",
             description="No one has added their LeetCode username yet.",
@@ -89,7 +89,7 @@ async def create_leaderboard(send_message, guild_id, user_id = None, timeframe: 
         await send_message(embed=embed)
         return
 
-    data = await read_file(f"data/{guild_id}_leetcode_stats.json")
+    data = await read_file(f"data/{server_id}_leetcode_stats.json")
 
     last_updated = data["last_updated"]
 
@@ -136,10 +136,10 @@ async def create_leaderboard(send_message, guild_id, user_id = None, timeframe: 
                     if winners_only and j == 1:
                         wins += 1
                     
-                wins_text = f" ({str(wins)} wins) "
+                wins_text = f"({str(wins)} wins) "
                 # wins won't be displayed for alltime timeframe as wins !> 0
                 leaderboard.append(
-                    f"**{RANK_EMOJI[j] if j in RANK_EMOJI else number_rank} {discord_username_with_link if link_yes_no else discord_username}**{wins_text if  wins > 0 else ''}- **{stats[TIMEFRAME_TITLE[timeframe]['field']]}** pts"
+                    f"**{RANK_EMOJI[j] if j in RANK_EMOJI else number_rank} {discord_username_with_link if link_yes_no else discord_username}** {wins_text if  wins > 0 else ''}- **{stats[TIMEFRAME_TITLE[timeframe]['field']]}** pts"
                 )
                 
 
@@ -176,19 +176,19 @@ class Leaderboards(commands.GroupCog, name="leaderboard"):
     async def alltime(self, interaction: discord.Interaction, page: int = 1):
         logger.info("file: cogs/leaderboards.py ~ alltime ~ run")
 
-        await create_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "alltime", page)
+        await display_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "alltime", page)
 
     @discord.app_commands.command(name="weekly", description="View the Weekly leaderboard")
     async def weekly(self, interaction: discord.Interaction, page: int = 1):
         logger.info("file: cogs/leaderboards.py ~ weekly ~ run")
 
-        await create_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "weekly", page)
+        await display_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "weekly", page)
 
     @discord.app_commands.command(name="daily", description="View the Daily leaderboard")
     async def daily(self, interaction: discord.Interaction, page: int = 1):
         logger.info("file: cogs/leaderboards.py ~ daily ~ run")
         
-        await create_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "daily", page)
+        await display_leaderboard(interaction.response.send_message, interaction.guild.id, interaction.user.id, "daily", page)
 
 
 async def setup(client):

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -8,7 +8,6 @@ from discord.ext import commands
 
 from bot_globals import DIFFICULTY_SCORE, logger
 from utils.io_handling import read_file, write_file
-from utils.leaderboards import send_leaderboard_winners
 
 
 def get_problems_solved_and_rank(leetcode_username: str):
@@ -86,8 +85,8 @@ def get_problems_solved_and_rank(leetcode_username: str):
 
 
 async def update_stats(client, now: datetime, daily_reset: bool = False, weekly_reset: bool = False):
-    logger.info("file: cogs/stats.py ~ update_stats ~ run ~ now: %s | weekly reset: %s",
-                now.strftime("%d/%m/%Y, %H:%M:%S"), weekly_reset)
+    logger.info("file: cogs/stats.py ~ update_stats ~ run ~ now: %s | daily reset: %s | weekly reset: %s",
+                now.strftime("%d/%m/%Y, %H:%M:%S"), daily_reset, weekly_reset)
 
     # retrieve every server the bot is in
     server_ids = [guild.id for guild in client.guilds]
@@ -105,8 +104,6 @@ async def update_stats(client, now: datetime, daily_reset: bool = False, weekly_
             places = {}
 
             if daily_reset:
-                await send_leaderboard_winners("daily", server_id)
-
                 today_score_sorted = sorted(data["users"].items(),
                                             key=lambda x: x[1]["today_score"],
                                             reverse=True)
@@ -118,8 +115,6 @@ async def update_stats(client, now: datetime, daily_reset: bool = False, weekly_
                     places[discord_id]["daily_ranking"] = place + 1
 
             if weekly_reset:
-                await send_leaderboard_winners("weekly", server_id)
-
                 week_score_sorted = sorted(data["users"].items(),
                                            key=lambda x: x[1]["week_score"],
                                            reverse=True)

--- a/cogs/users.py
+++ b/cogs/users.py
@@ -6,9 +6,10 @@ import string
 
 import discord
 from discord.ext import commands
-from cogs.stats import get_problems_solved_and_rank
 
 from bot_globals import DIFFICULTY_SCORE, logger
+from cogs.stats import get_problems_solved_and_rank
+from utils.io_handling import read_file, write_file
 
 
 class Users(commands.Cog):
@@ -26,8 +27,8 @@ class Users(commands.Cog):
         discord_user = interaction.user
 
         if os.path.exists(f"data/{interaction.guild.id}_leetcode_stats.json"):
-            with open(f"data/{interaction.guild.id}_leetcode_stats.json", "r", encoding="UTF-8") as file:
-                existing_data = json.load(file)
+            existing_data = await read_file(f"data/{interaction.guild.id}_leetcode_stats.json")
+
             if leetcode_username in existing_data:
                 embed = discord.Embed(
                     title="Error!",
@@ -108,8 +109,8 @@ class Users(commands.Cog):
                 "daily_rankings": {}
             }
 
-            with open(f"data/{interaction.guild.id}_leetcode_stats.json", "w", encoding="UTF-8") as file:
-                json.dump(existing_data, file)
+            await write_file(f"data/{interaction.guild.id}_leetcode_stats.json", existing_data)
+
             embed = discord.Embed(title="Profile Added",
                                   color=discord.Color.green())
             embed.add_field(name="Username:",
@@ -135,8 +136,7 @@ class Users(commands.Cog):
         # Check if the file exists
         if os.path.exists(f"data/{interaction.guild.id}_leetcode_stats.json"):
             # Open the file
-            with open(f"data/{interaction.guild.id}_leetcode_stats.json", "r", encoding="UTF-8") as file:
-                data = json.load(file)
+            data = await read_file(f"data/{interaction.guild.id}_leetcode_stats.json")
 
             logger.info(
                 'file: cogs/users.py ~ delete ~ discord_user.id: %s', discord_user.id)
@@ -149,8 +149,8 @@ class Users(commands.Cog):
                 # Delete the data point
                 del data["users"][str(discord_user.id)]
                 # Save the updated data
-                with open(f"data/{interaction.guild.id}_leetcode_stats.json", "w", encoding="UTF-8") as file:
-                    json.dump(data, file)
+                await write_file(f"data/{interaction.guild.id}_leetcode_stats.json", data)
+
                 # Send a message to the user
                 embed = discord.Embed(title="Profile Deleted",
                                       color=discord.Color.green())

--- a/cogs/users.py
+++ b/cogs/users.py
@@ -25,9 +25,10 @@ class Users(commands.Cog):
             'file: cogs/users.py ~ add ~ run ~ leetcode_username: %s', leetcode_username)
 
         discord_user = interaction.user
+        server_id = interaction.guild.id
 
-        if os.path.exists(f"data/{interaction.guild.id}_leetcode_stats.json"):
-            existing_data = await read_file(f"data/{interaction.guild.id}_leetcode_stats.json")
+        if os.path.exists(f"data/{server_id}_leetcode_stats.json"):
+            existing_data = await read_file(f"data/{server_id}_leetcode_stats.json")
 
             if leetcode_username in existing_data:
                 embed = discord.Embed(
@@ -109,7 +110,7 @@ class Users(commands.Cog):
                 "daily_rankings": {}
             }
 
-            await write_file(f"data/{interaction.guild.id}_leetcode_stats.json", existing_data)
+            await write_file(f"data/{server_id}_leetcode_stats.json", existing_data)
 
             embed = discord.Embed(title="Profile Added",
                                   color=discord.Color.green())
@@ -132,11 +133,12 @@ class Users(commands.Cog):
             'file: cogs/users.py ~ delete ~ run')
 
         discord_user = interaction.user
+        server_id = interaction.guild.id
 
         # Check if the file exists
-        if os.path.exists(f"data/{interaction.guild.id}_leetcode_stats.json"):
+        if os.path.exists(f"data/{server_id}_leetcode_stats.json"):
             # Open the file
-            data = await read_file(f"data/{interaction.guild.id}_leetcode_stats.json")
+            data = await read_file(f"data/{server_id}_leetcode_stats.json")
 
             logger.info(
                 'file: cogs/users.py ~ delete ~ discord_user.id: %s', discord_user.id)
@@ -149,7 +151,7 @@ class Users(commands.Cog):
                 # Delete the data point
                 del data["users"][str(discord_user.id)]
                 # Save the updated data
-                await write_file(f"data/{interaction.guild.id}_leetcode_stats.json", data)
+                await write_file(f"data/{server_id}_leetcode_stats.json", data)
 
                 # Send a message to the user
                 embed = discord.Embed(title="Profile Deleted",

--- a/main.py
+++ b/main.py
@@ -112,7 +112,9 @@ async def on_ready():
     logger.info('file: main.py ~ server IDs: %s', server_ids)
 
     if os.environ["UPDATE_STATS_ON_START"] == "True":
-        await update_stats(client, datetime.now(TIMEZONE))
+        daily_reset = os.environ["DAILY_RESET"] == "True"
+        weekly_reset = os.environ["WEEKLY_RESET"] == "True"
+        await update_stats(client, datetime.now(TIMEZONE), daily_reset, weekly_reset)
 
     try:
         synced = await client.tree.sync()

--- a/utils/io_handling.py
+++ b/utils/io_handling.py
@@ -1,0 +1,19 @@
+import json
+import os
+
+from utils.run_blocking import to_thread
+
+
+@to_thread
+def read_file(path):
+    if os.path.exists(path):
+        with open(path, 'r', encoding="UTF-8") as file:
+            data = json.load(file)
+        return data
+    return None
+
+
+@to_thread
+def write_file(path, data):
+    with open(path, "w", encoding="UTF-8") as file:
+        json.dump(data, file, indent=4)

--- a/utils/leaderboards.py
+++ b/utils/leaderboards.py
@@ -1,21 +1,21 @@
-
-from typing import List
+import os
 
 from bot_globals import client, logger
-from cogs.leaderboards import create_leaderboard
+from cogs.leaderboards import display_leaderboard
+from utils.io_handling import read_file
 
 
-async def send_leaderboard_winners(timeframe: str, guild_id: int, specific_channels: List[int] = None):
-    channels = []
-    if specific_channels is not None:
-        channels = specific_channels
-    else:
-        with open('dailychannels.txt', 'r', encoding="UTF-8") as f:
-            channels = [channel.strip() for channel in f.readlines()]
+async def send_leaderboard_winners(timeframe: str):
+    for filename in os.listdir("./data"):
+        if filename.endswith(".json"):
+            server_id = int(filename.split("_")[0])
 
-    for channel_id in channels:
-        channel = client.get_channel(int(channel_id))
-        await create_leaderboard(channel.send, guild_id, timeframe=timeframe, winners_only=True, users_per_page=3)
+            data = await read_file(f"data/{server_id}_leetcode_stats.json")
+
+            if "channels" in data:
+                for channel_id in data["channels"]:
+                    channel = client.get_channel(channel_id)
+                    await display_leaderboard(channel.send, server_id, timeframe=timeframe, winners_only=True, users_per_page=3)
 
     logger.info(
         "file: utils/leaderboards.py ~ send_leaderboard_winners ~ %s winners leaderboard sent to channels", timeframe)


### PR DESCRIPTION
- Make update_stats async. Create io_handling functions for reading and writing to JSON files and wrap with to_thread as they are blocking functions. Revert to previous way of displaying leaderboard but with new order.
- fix send_leaderboard_winners sending every server's leaderboard to all the channels by storing the server's respective channels into the JSONs. This means that dailychannels.txt is now not necessary